### PR TITLE
fix: socket deinitialization warning

### DIFF
--- a/src/screens/run/index.tsx
+++ b/src/screens/run/index.tsx
@@ -93,26 +93,33 @@ export const Run = (props: RunProps) => {
 
   // Effects triggered by server events
   useEffect(() => {
-    socket.on('game_paused', (data: any) => {
-      // Play sound
-      playPauseSound();
-      // Set pause state
-      setIsPaused(true);
-      setPauser(data.pauser);
-    });
+    if (socket) {
+      const handleGamePaused = (data: any) => {
+        playPauseSound();
+        setIsPaused(true);
+        setPauser(data.pauser);
+      };
 
-    socket.on('game_resumed', (_data: any) => {
-      // Play sound
-      playResumeSound();
-      // Set countdown
-      setIsCountdown(true);
-      setTimeout(() => {
-        setIsCountdown(false);
-        // Set pause state
-        setIsPaused(false);
-        setPauser('');
-      }, 5000);
-    });
+      const handleGameResumed = (_data: any) => {
+        playResumeSound();
+        setIsCountdown(true);
+        setTimeout(() => {
+          setIsCountdown(false);
+          setIsPaused(false);
+          setPauser('');
+        }, 5000);
+      };
+
+      socket.on('game_paused', handleGamePaused);
+      socket.on('game_resumed', handleGameResumed);
+
+      return () => {
+        if (socket) {
+          socket.off('game_paused', handleGamePaused);
+          socket.off('game_resumed', handleGameResumed);
+        }
+      };
+    }
   }, [props.gameId]);
 
   useEffect(() => {

--- a/src/screens/run_report/run-report.tsx
+++ b/src/screens/run_report/run-report.tsx
@@ -117,7 +117,7 @@ export const RunReport = ({ gameId, runId }: RunReportProps) => {
 
   const [leaderboardData, setLeaderboardData] = useState<any[]>([]);
 
-  socket.on('game_ended', async (data: any) => {
+  socket.on('game_ended', async (_data: any) => {
     setGameEnded(true);
   });
 


### PR DESCRIPTION
Added check to ensure `socket` is not null before calling `socket.off()` in deinitialization code. This was causing internal warnings upon logout when `socket` was already set to null as part of the logout logic. 