### PR TITLE
Fix User State on Hydrate and Release Android App v3

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -86,8 +86,8 @@ android {
         applicationId 'com.runstarter.development'
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 2
-        versionName "1.0.2"
+        versionCode 3
+        versionName "1.0.3"
 
         buildConfigField("boolean", "REACT_NATIVE_UNSTABLE_USE_RUNTIME_SCHEDULER_ALWAYS", (findProperty("reactNative.unstable_useRuntimeSchedulerAlways") ?: true).toString())
     }

--- a/server/server-utils.tsx
+++ b/server/server-utils.tsx
@@ -60,13 +60,13 @@ export const deinitializeSocket = () => {
   }
 };
 
-export const createGame = () => {
-  if (!auth.currentUser) {
+export const createGame = (userID: string) => {
+  if (userID === '') {
     console.log('NO USER FOUND!');
     return;
   }
   var gameID = '';
-  socket.emit('create_game', { user_id: auth.currentUser.uid }, (data: any) => {
+  socket.emit('create_game', { user_id: userID }, (data: any) => {
     console.log('Returned data:', data);
     gameID = data.game_id;
   });

--- a/src/database/runs/fetch-runs.ts
+++ b/src/database/runs/fetch-runs.ts
@@ -22,7 +22,7 @@ export const fetchRunsForUser = async (userId: string) => {
     });
   });
 
-  // Sort runs by datetime (most recent first) 
+  // Sort runs by datetime (most recent first)
   runData.sort((a, b) => {
     return b.createdAt - a.createdAt;
   });

--- a/src/screens/new_run/index.tsx
+++ b/src/screens/new_run/index.tsx
@@ -35,6 +35,7 @@ export const NewRun: React.FC<{ gameId?: string }> = ({ gameId }) => {
   const [friends, setFriends] = useState<User[]>([]);
   // hook for friend invites bottom sheet
   const sheetRef = useRef<BottomSheet>(null);
+  const userId = useAuth().userId;
   const currentUser = useAuth().currentUser;
   const navigation = useNavigation();
   const [isRunModalVisible, setRunModalVisibility] = useState(false);
@@ -43,11 +44,10 @@ export const NewRun: React.FC<{ gameId?: string }> = ({ gameId }) => {
   const [players, setPlayers] = useState<User[]>([]);
   const [invitedIds, setInvitedIds] = useState<string[]>([]);
   const [isAwaitingGameStart, setIsAwaitingGameStart] = useState(false);
-
+  
   useEffect(() => {
-    console.log('gameId', gameId);
     if (!gameId || gameId === '') {
-      createGame();
+      createGame(userId);
     } else {
       // If a gameId is passed, use it as the roomID
       setRoomID(gameId);
@@ -112,7 +112,7 @@ export const NewRun: React.FC<{ gameId?: string }> = ({ gameId }) => {
     setInvitedIds([]);
     // Navigate back to home screen
     navigation.navigate('Games'); // Already in 'Games'
-    gameId = createGame();
+    gameId = createGame(userId);
   };
 
   const handleSheetChange = useCallback(() => {

--- a/src/screens/new_run/index.tsx
+++ b/src/screens/new_run/index.tsx
@@ -35,7 +35,7 @@ export const NewRun: React.FC<{ gameId?: string }> = ({ gameId }) => {
   const [friends, setFriends] = useState<User[]>([]);
   // hook for friend invites bottom sheet
   const sheetRef = useRef<BottomSheet>(null);
-  const userId = useAuth().userId;
+  const userId = useAuth().userId; // required for creating a game (useAuth::currentUser is null on first render)
   const currentUser = useAuth().currentUser;
   const navigation = useNavigation();
   const [isRunModalVisible, setRunModalVisibility] = useState(false);
@@ -44,7 +44,7 @@ export const NewRun: React.FC<{ gameId?: string }> = ({ gameId }) => {
   const [players, setPlayers] = useState<User[]>([]);
   const [invitedIds, setInvitedIds] = useState<string[]>([]);
   const [isAwaitingGameStart, setIsAwaitingGameStart] = useState(false);
-  
+
   useEffect(() => {
     if (!gameId || gameId === '') {
       createGame(userId);
@@ -53,7 +53,7 @@ export const NewRun: React.FC<{ gameId?: string }> = ({ gameId }) => {
       setRoomID(gameId);
       joinGame(gameId);
     }
-  }, [gameId]);
+  }, [gameId, userId]);
 
   // Only set up the socket listener for game creation if we are creating a new game
   useEffect(() => {

--- a/src/screens/server_interaction_example/index.tsx
+++ b/src/screens/server_interaction_example/index.tsx
@@ -12,6 +12,7 @@ import {
 } from 'server/server-utils';
 
 import { Button } from '@/ui';
+import { useAuth } from '@/core';
 
 interface JoinGameButtonProps {
   roomSetter: (roomId: string) => void;
@@ -65,6 +66,7 @@ export const ServerTest: React.FC = () => {
   const [roomID, setRoomID] = useState('');
   const [players, setPlayers] = useState([]);
   const [lastStatus, setLastStatus] = useState('');
+  const userId = useAuth().userId;
 
   // Can add your own user ID (from Firebase auth page) here for testing.
   // In prod, should query who to invite from friends list
@@ -88,7 +90,7 @@ export const ServerTest: React.FC = () => {
       <Button
         label="Create Game"
         onPress={() => {
-          createGame();
+          createGame(userId);
         }}
       />
 

--- a/src/screens/server_interaction_example/index.tsx
+++ b/src/screens/server_interaction_example/index.tsx
@@ -11,8 +11,8 @@ import {
   startGame,
 } from 'server/server-utils';
 
-import { Button } from '@/ui';
 import { useAuth } from '@/core';
+import { Button } from '@/ui';
 
 interface JoinGameButtonProps {
   roomSetter: (roomId: string) => void;


### PR DESCRIPTION
User state did not update on hydrate, previously game does not start as user state is always null when closing and reopening the app (on hydrate).

In the `NewRun` component, `useAuth().currentUser` is always null on hydrate, but `useAuth().userId` is always saved locally and hence present, so we must use it as the user's id to create a game. 

Changes:
- Refactored `createGame()` in `server-utils.tsx` to take in a `userId`
- Use `useAuth().userId` to pass into `createGame()`, as using `useAuth().currentUser.id` will not work after app is hydrated.
- Bundled and released v3 of Android App